### PR TITLE
chore: update machine management configuration

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -32,8 +32,8 @@ jobs:
           DB_TABLE: ${{ secrets.DB_TABLE }}
           LINE_CHANNEL_ACCESS_TOKEN: ${{ secrets.LINE_CHANNEL_ACCESS_TOKEN }}
           LINE_CHANNEL_SECRET: ${{ secrets.LINE_CHANNEL_SECRET }}
-          AUTO_STOP_MACHINES: ${{ secrets.AUTO_STOP_MACHINES }}
           PORT: ${{ secrets.PORT }}
+          MIN_MACHINES_RUNNING: ${{ vars.MIN_MACHINES_RUNNING }}
         run: |
           sed -i -e "s|replace_APP_HOST|\"$APP_HOST\"|g" fly.toml
           sed -i -e "s|replace_DB_PORT|\"$DB_PORT\"|g" fly.toml
@@ -46,6 +46,7 @@ jobs:
           sed -i -e "s|replace_LINE_CHANNEL_SECRET|\"$LINE_CHANNEL_SECRET\"|g" fly.toml
           sed -i -e "s|replace_PORT|$PORT|g" fly.toml
           sed -i -e "s|replace_AUTO_STOP_MACHINES|$AUTO_STOP_MACHINES|g" fly.toml
+          sed -i -e "s|replace_MIN_MACHINES_RUNNING|$MIN_MACHINES_RUNNING|g" fly.toml
           cat fly.toml
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,8 +22,8 @@ jobs:
           DB_TABLE: ${{ secrets.DB_TABLE }}
           LINE_CHANNEL_ACCESS_TOKEN: ${{ secrets.LINE_CHANNEL_ACCESS_TOKEN }}
           LINE_CHANNEL_SECRET: ${{ secrets.LINE_CHANNEL_SECRET }}
-          AUTO_STOP_MACHINES: ${{ secrets.AUTO_STOP_MACHINES }}
           PORT: ${{ secrets.PORT }}
+          MIN_MACHINES_RUNNING: ${{ vars.MIN_MACHINES_RUNNING }}
         run: |
           sed -i -e "s|replace_APP_HOST|\"$APP_HOST\"|g" fly.toml
           sed -i -e "s|replace_DB_PORT|\"$DB_PORT\"|g" fly.toml
@@ -36,7 +36,7 @@ jobs:
           sed -i -e "s|replace_LINE_CHANNEL_SECRET|\"$LINE_CHANNEL_SECRET\"|g" fly.toml
           sed -i -e "s|replace_PORT|$PORT|g" fly.toml
           sed -i -e "s|replace_AUTO_STOP_MACHINES|$AUTO_STOP_MACHINES|g" fly.toml
-          cat fly.toml
+          sed -i -e "s|replace_MIN_MACHINES_RUNNING|$MIN_MACH
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - run: |
           flyctl deploy --remote-only

--- a/fly.toml
+++ b/fly.toml
@@ -23,7 +23,7 @@ primary_region = "nrt"
 [http_service]
   internal_port = replace_PORT
   force_https = true
-  auto_stop_machines = replace_AUTO_STOP_MACHINES
+  auto_stop_machines = true
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = replace_MIN_MACHINES_RUNNING
   processes = ["app"]


### PR DESCRIPTION
- Remove the `AUTO_STOP_MACHINES` secret from the dev.yml and main.yml files
- Add the `MIN_MACHINES_RUNNING` secret to the dev.yml and main.yml files
- Update the `fly.toml` file to set `auto_stop_machines` to `true`
- Update the `fly.toml` file to set `min_machines_running` to the value of `MIN_MACHINES_RUNNING` secret

Signed-off-by: FionnKuo <>