### PR TITLE
chore: remove line replacing AUTO_STOP_MACHINES in fly.toml for dev.y…

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -45,7 +45,6 @@ jobs:
           sed -i -e "s|replace_LINE_CHANNEL_ACCESS_TOKEN|\"$LINE_CHANNEL_ACCESS_TOKEN\"|g" fly.toml
           sed -i -e "s|replace_LINE_CHANNEL_SECRET|\"$LINE_CHANNEL_SECRET\"|g" fly.toml
           sed -i -e "s|replace_PORT|$PORT|g" fly.toml
-          sed -i -e "s|replace_AUTO_STOP_MACHINES|$AUTO_STOP_MACHINES|g" fly.toml
           sed -i -e "s|replace_MIN_MACHINES_RUNNING|$MIN_MACHINES_RUNNING|g" fly.toml
           cat fly.toml
       - uses: superfly/flyctl-actions/setup-flyctl@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,6 @@ jobs:
           sed -i -e "s|replace_LINE_CHANNEL_ACCESS_TOKEN|\"$LINE_CHANNEL_ACCESS_TOKEN\"|g" fly.toml
           sed -i -e "s|replace_LINE_CHANNEL_SECRET|\"$LINE_CHANNEL_SECRET\"|g" fly.toml
           sed -i -e "s|replace_PORT|$PORT|g" fly.toml
-          sed -i -e "s|replace_AUTO_STOP_MACHINES|$AUTO_STOP_MACHINES|g" fly.toml
           sed -i -e "s|replace_MIN_MACHINES_RUNNING|$MIN_MACHINES_RUNNING|g" fly.toml
           cat fly.toml
       - uses: superfly/flyctl-actions/setup-flyctl@master


### PR DESCRIPTION
…ml and main.yml

- Remove the line that replaces `AUTO_STOP_MACHINES` in `fly.toml` for `dev.yml` and `main.yml`

Signed-off-by: FionnKuo <>